### PR TITLE
fix(package.json): delete TypeScript peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,6 @@
 		"test:unit": "ts-mocha -p ./tsconfig.stryker.json",
 		"ts:check": "tsc --noEmit"
 	},
-	"peerDependencies": {
-		"typescript": "*"
-	},
 	"devDependencies": {
 		"@commitlint/cli": "^17.0.2",
 		"@commitlint/config-conventional": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8740,8 +8740,6 @@ __metadata:
     ts-mocha: ^10.0.0
     ts-node: ^10.8.1
     typescript: ^4.7.3
-  peerDependencies:
-    typescript: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Yarn should not emit warning when ts-predicate is used in dependency by a package