### PR TITLE
feat: add StringConstraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,23 @@ Asserts that the value is a number, but not NaN nor +/-Infinity.
 ### IsString
 
 ```ts
-static IsString(value: unknown): void
+static IsString(value: unknown, constraints?: StringConstraints): void
 ```
 
 Asserts that the value is a string.
+
+The optional parameter `constraints` accept an object described by the following interface.
+
+```ts
+interface StringConstraints
+{
+	minLength?: number;
+	maxLength?: number;
+}
+```
+
+If `minLength` is provided, it'll asserts that the value has at least this length.<br />
+If `maxLength` is provided, it'll asserts that the value has at most this length.
 
 ### IsPopulatedString
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ interface StringConstraints
 If `minLength` is provided, it'll asserts that the value has at least this length.<br />
 If `maxLength` is provided, it'll asserts that the value has at most this length.
 
-### IsPopulatedString
+### IsFilledString
 
 ```ts
-static IsPopulatedString(value: unknown): void
+static IsFilledString(value: unknown): void
 ```
 
 Like `IsString`, but asserts that the string is never empty too.
@@ -232,10 +232,10 @@ static IsString(value: unknown): boolean
 
 Narrow down the value to being a string.
 
-### IsPopulatedString
+### IsFilledString
 
 ```ts
-static IsPopulatedString(value: unknown): void
+static IsFilledString(value: unknown): void
 ```
 
 Asserts that the value is a non empty string.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ static IsString(value: unknown): void
 
 Asserts that the value is a string.
 
+### IsPopulatedString
+
+```ts
+static IsPopulatedString(value: unknown): void
+```
+
+Like `IsString`, but asserts that the string is never empty too.
+
 ### IsArray
 
 ```ts
@@ -210,6 +218,14 @@ static IsString(value: unknown): boolean
 ```
 
 Narrow down the value to being a string.
+
+### IsPopulatedString
+
+```ts
+static IsPopulatedString(value: unknown): void
+```
+
+Asserts that the value is a non empty string.
 
 ### IsArray
 

--- a/__tests__/TypeAssertion.spec.ts
+++ b/__tests__/TypeAssertion.spec.ts
@@ -368,7 +368,7 @@ describe(
 		);
 
 		describe(
-			"IsPopulatedString",
+			"IsFilledString",
 			(): void =>
 			{
 				it(
@@ -383,7 +383,7 @@ describe(
 							expect(
 								(): void =>
 								{
-									TypeAssertion.IsPopulatedString(ITEM);
+									TypeAssertion.IsFilledString(ITEM);
 								}
 							).to.not.throw();
 						}
@@ -401,7 +401,7 @@ describe(
 							expect(
 								(): void =>
 								{
-									TypeAssertion.IsPopulatedString(ITEM);
+									TypeAssertion.IsFilledString(ITEM);
 								}
 							).to.throw(/^value /);
 						}

--- a/__tests__/TypeAssertion.spec.ts
+++ b/__tests__/TypeAssertion.spec.ts
@@ -328,7 +328,7 @@ describe(
 							{
 								TypeAssertion.IsString("Allan", { minLength: 6 });
 							}
-						).to.throw();
+						).to.throw("value length is shorter than minimum length 6");
 					}
 				);
 
@@ -361,7 +361,7 @@ describe(
 							{
 								TypeAssertion.IsString("Allan", { maxLength: 4 });
 							}
-						).to.throw();
+						).to.throw("value length is greater than maximum length 4");
 					}
 				);
 			}

--- a/__tests__/TypeAssertion.spec.ts
+++ b/__tests__/TypeAssertion.spec.ts
@@ -298,6 +298,72 @@ describe(
 						}
 					}
 				);
+
+				it(
+					"should return when given a string with a length greater or equal to the minLength constraint",
+					(): void =>
+					{
+						expect(
+							(): void =>
+							{
+								TypeAssertion.IsString("Allan", { minLength: 1 });
+							}
+						).to.not.throw();
+
+						expect(
+							(): void =>
+							{
+								TypeAssertion.IsString("Allan", { minLength: 5 });
+							}
+						).to.not.throw();
+					}
+				);
+
+				it(
+					"should throw when given a string with a length shorter than minLength constraint",
+					(): void =>
+					{
+						expect(
+							(): void =>
+							{
+								TypeAssertion.IsString("Allan", { minLength: 6 });
+							}
+						).to.throw();
+					}
+				);
+
+				it(
+					"should return when given a string with a length shorter or equal to the maxLength constraint",
+					(): void =>
+					{
+						expect(
+							(): void =>
+							{
+								TypeAssertion.IsString("Allan", { maxLength: 10 });
+							}
+						).to.not.throw();
+
+						expect(
+							(): void =>
+							{
+								TypeAssertion.IsString("Allan", { maxLength: 5 });
+							}
+						).to.not.throw();
+					}
+				);
+
+				it(
+					"should throw when given a string with a length greater than maxLength constraint",
+					(): void =>
+					{
+						expect(
+							(): void =>
+							{
+								TypeAssertion.IsString("Allan", { maxLength: 4 });
+							}
+						).to.throw();
+					}
+				);
 			}
 		);
 

--- a/__tests__/TypeAssertion.spec.ts
+++ b/__tests__/TypeAssertion.spec.ts
@@ -302,6 +302,49 @@ describe(
 		);
 
 		describe(
+			"IsPopulatedString",
+			(): void =>
+			{
+				it(
+					"should return when given a non empty string",
+					(): void =>
+					{
+						const VALUES: Array<unknown> = getValues(BaseType.STRING)
+							.filter((value) => { return value !== ""; });
+
+						for (const ITEM of VALUES)
+						{
+							expect(
+								(): void =>
+								{
+									TypeAssertion.IsPopulatedString(ITEM);
+								}
+							).to.not.throw();
+						}
+					}
+				);
+
+				it(
+					"should throw when given anything else",
+					(): void =>
+					{
+						const VALUES: Array<unknown> = [...getInvertedValues(BaseType.STRING), ""];
+
+						for (const ITEM of VALUES)
+						{
+							expect(
+								(): void =>
+								{
+									TypeAssertion.IsPopulatedString(ITEM);
+								}
+							).to.throw(/^value /);
+						}
+					}
+				);
+			}
+		);
+
+		describe(
 			"IsArray",
 			(): void =>
 			{
@@ -434,7 +477,7 @@ describe(
 				);
 
 				it(
-					"should throw when given a populated array",
+					"should return when given a populated array",
 					(): void =>
 					{
 						expect(

--- a/__tests__/TypeGuard.spec.ts
+++ b/__tests__/TypeGuard.spec.ts
@@ -260,6 +260,40 @@ describe(
 						}
 					}
 				);
+
+				it(
+					"should return true when given a string with a length greater or equal to the minLength constraint",
+					(): void =>
+					{
+						expect(TypeGuard.IsString("Allan", { minLength: 2 })).to.be.true;
+						expect(TypeGuard.IsString("Allan", { minLength: 5 })).to.be.true;
+					}
+				);
+
+				it(
+					"should return false when given an array with a length below the minLength constraint",
+					(): void =>
+					{
+						expect(TypeGuard.IsString("Allan", { minLength: 6 })).to.be.false;
+					}
+				);
+
+				it(
+					"should return true when given a string with a length shorter or equal to the maxLength constraint",
+					(): void =>
+					{
+						expect(TypeGuard.IsString("Allan", { maxLength: 5 })).to.be.true;
+						expect(TypeGuard.IsString("Allan", { maxLength: 10 })).to.be.true;
+					}
+				);
+
+				it(
+					"should return false when given a string with a length above the maxLength constraint",
+					(): void =>
+					{
+						expect(TypeGuard.IsString("Allan", { maxLength: 2 })).to.be.false;
+					}
+				);
 			}
 		);
 

--- a/__tests__/TypeGuard.spec.ts
+++ b/__tests__/TypeGuard.spec.ts
@@ -298,7 +298,7 @@ describe(
 		);
 
 		describe(
-			"IsPopulatedString",
+			"IsFilledString",
 			(): void =>
 			{
 				it(
@@ -310,7 +310,7 @@ describe(
 
 						for (const ITEM of VALUES)
 						{
-							expect(TypeGuard.IsPopulatedString(ITEM)).to.be.true;
+							expect(TypeGuard.IsFilledString(ITEM)).to.be.true;
 						}
 					}
 				);
@@ -323,7 +323,7 @@ describe(
 
 						for (const ITEM of VALUES)
 						{
-							expect(TypeGuard.IsPopulatedString(ITEM)).to.be.false;
+							expect(TypeGuard.IsFilledString(ITEM)).to.be.false;
 						}
 					}
 				);

--- a/__tests__/TypeGuard.spec.ts
+++ b/__tests__/TypeGuard.spec.ts
@@ -264,6 +264,39 @@ describe(
 		);
 
 		describe(
+			"IsPopulatedString",
+			(): void =>
+			{
+				it(
+					"should return true when given a populated string",
+					(): void =>
+					{
+						const VALUES: Array<unknown> = getValues(BaseType.STRING)
+							.filter((value) => { return value !== ""; });
+
+						for (const ITEM of VALUES)
+						{
+							expect(TypeGuard.IsPopulatedString(ITEM)).to.be.true;
+						}
+					}
+				);
+
+				it(
+					"should return false when given anything else",
+					(): void =>
+					{
+						const VALUES: Array<unknown> = [...getInvertedValues(BaseType.STRING), ""];
+
+						for (const ITEM of VALUES)
+						{
+							expect(TypeGuard.IsPopulatedString(ITEM)).to.be.false;
+						}
+					}
+				);
+			}
+		);
+
+		describe(
 			"IsArray",
 			(): void =>
 			{

--- a/src/TypeAssertion.ts
+++ b/src/TypeAssertion.ts
@@ -140,16 +140,16 @@ class TypeAssertion
 	}
 
 	/**
-	* IsPopulatedString
+	* IsFilledString
 	*
-	* @description Assertion that check if a value is a string.
+	* @description Assertion that check if a value is non empty string.
 	* @public
 	* @static
 	* @param {unknown} value the value
 	* @throws {Error} if the value is not a string
 	* @return {void} nothing
 	*/
-	public static IsPopulatedString(value: unknown): asserts value is string
+	public static IsFilledString(value: unknown): asserts value is string
 	{
 		if (!TypeGuard.IsString(value))
 		{

--- a/src/TypeAssertion.ts
+++ b/src/TypeAssertion.ts
@@ -151,15 +151,12 @@ class TypeAssertion
 	*/
 	public static IsFilledString(value: unknown): asserts value is string
 	{
-		if (!TypeGuard.IsString(value))
-		{
-			throw new Error("value is not a string");
-		}
-
-		if (value === "")
-		{
-			throw new Error("value is an empty string");
-		}
+		TypeAssertion.IsString(value, {
+			/**
+			 *
+			 */
+			minLength: 1,
+		});
 	}
 
 	/**

--- a/src/TypeAssertion.ts
+++ b/src/TypeAssertion.ts
@@ -130,12 +130,12 @@ class TypeAssertion
 
 		if (constraints.minLength !== undefined && value.length < constraints.minLength)
 		{
-			throw new Error(`value is shorter than minimum length ${constraints.minLength.toString()}`);
+			throw new Error(`value length is shorter than minimum length ${constraints.minLength.toString()}`);
 		}
 
 		if (constraints.maxLength !== undefined && value.length > constraints.maxLength)
 		{
-			throw new Error(`value is longer than maximum length ${constraints.maxLength.toString()}`);
+			throw new Error(`value length is greater than maximum length ${constraints.maxLength.toString()}`);
 		}
 	}
 

--- a/src/TypeAssertion.ts
+++ b/src/TypeAssertion.ts
@@ -122,6 +122,29 @@ class TypeAssertion
 	}
 
 	/**
+	* IsPopulatedString
+	*
+	* @description Assertion that check if a value is a string.
+	* @public
+	* @static
+	* @param {unknown} value the value
+	* @throws {Error} if the value is not a string
+	* @return {void} nothing
+	*/
+	public static IsPopulatedString(value: unknown): asserts value is string
+	{
+		if (!TypeGuard.IsString(value))
+		{
+			throw new Error("value is not a string");
+		}
+
+		if (value === "")
+		{
+			throw new Error("value is an empty string");
+		}
+	}
+
+	/**
 	* IsArray
 	*
 	* @description Assertion that check if a value is an array.

--- a/src/TypeAssertion.ts
+++ b/src/TypeAssertion.ts
@@ -1,6 +1,6 @@
 import { TypeGuard } from "./TypeGuard.js";
 
-import type { ArrayConstraints, ObjectWithNullableProperty, ObjectWithProperty, PopulatedArray } from "./Types.js";
+import type { ArrayConstraints, ObjectWithNullableProperty, ObjectWithProperty, PopulatedArray, StringConstraints } from "./Types.js";
 
 /**
 * TypeAssertion
@@ -110,14 +110,32 @@ class TypeAssertion
 	* @public
 	* @static
 	* @param {unknown} value the value
+	* @param {object} [constraints] some additional check
+	* @param {number} [constraints.minLength] minimal length
+	* @param {number} [constraints.maxLength] maximum length
 	* @throws {Error} if the value is not a string
 	* @return {void} nothing
 	*/
-	public static IsString(value: unknown): asserts value is string
+	public static IsString(value: unknown, constraints?: StringConstraints): asserts value is string
 	{
 		if (!TypeGuard.IsString(value))
 		{
 			throw new Error("value is not a string");
+		}
+
+		if (constraints === undefined)
+		{
+			return;
+		}
+
+		if (constraints.minLength !== undefined && value.length < constraints.minLength)
+		{
+			throw new Error(`value is shorter than minimum length ${constraints.minLength.toString()}`);
+		}
+
+		if (constraints.maxLength !== undefined && value.length > constraints.maxLength)
+		{
+			throw new Error(`value is longer than maximum length ${constraints.maxLength.toString()}`);
 		}
 	}
 

--- a/src/TypeGuard.ts
+++ b/src/TypeGuard.ts
@@ -139,7 +139,7 @@ class TypeGuard
 	}
 
 	/**
-	* IsPopulatedString
+	* IsFilledString
 	*
 	* @description Predicate that check if a value is a non empty string.
 	* @public
@@ -147,7 +147,7 @@ class TypeGuard
 	* @param {unknown} value the value
 	* @return {boolean} a boolean
 	*/
-	public static IsPopulatedString(
+	public static IsFilledString(
 		value: unknown,
 	): value is string
 	{

--- a/src/TypeGuard.ts
+++ b/src/TypeGuard.ts
@@ -151,7 +151,12 @@ class TypeGuard
 		value: unknown,
 	): value is string
 	{
-		return TypeGuard.IsString(value) && value !== "";
+		return TypeGuard.IsString(value, {
+			/**
+			 *
+			 */
+			minLength: 1
+		});
 	}
 
 	/**

--- a/src/TypeGuard.ts
+++ b/src/TypeGuard.ts
@@ -116,6 +116,22 @@ class TypeGuard
 	}
 
 	/**
+	* IsPopulatedString
+	*
+	* @description Predicate that check if a value is a non empty string.
+	* @public
+	* @static
+	* @param {unknown} value the value
+	* @return {boolean} a boolean
+	*/
+	public static IsPopulatedString(
+		value: unknown,
+	): value is string
+	{
+		return TypeGuard.IsString(value) && value !== "";
+	}
+
+	/**
 	* IsString
 	*
 	* @description Predicate that check if a value is a string.

--- a/src/TypeGuard.ts
+++ b/src/TypeGuard.ts
@@ -1,4 +1,4 @@
-import type { ArrayConstraints, ObjectWithNullableProperty, ObjectWithProperty, PopulatedArray } from "./Types.js";
+import type { ArrayConstraints, ObjectWithNullableProperty, ObjectWithProperty, PopulatedArray, StringConstraints } from "./Types.js";
 
 /**
 * TypeGuard
@@ -108,11 +108,34 @@ class TypeGuard
 	* @public
 	* @static
 	* @param {unknown} value the value
+	* @param {object} [constraints] some additional check
+	* @param {number} [constraints.minLength] minimal length
+	* @param {number} [constraints.maxLength] maximum length
 	* @return {boolean} a boolean
 	*/
-	public static IsString(value: unknown): value is string
+	public static IsString(value: unknown, constraints?: StringConstraints): value is string
 	{
-		return typeof value === "string";
+		if (typeof value !== "string")
+		{
+			return false;
+		}
+
+		if (constraints === undefined)
+		{
+			return true;
+		}
+
+		if (constraints.minLength !== undefined && value.length < constraints.minLength)
+		{
+			return false;
+		}
+
+		if (constraints.maxLength !== undefined && value.length > constraints.maxLength)
+		{
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -32,4 +32,19 @@ interface ArrayConstraints<Type>
 	itemGuard?: (item: unknown) => item is Type;
 }
 
-export type { ArrayConstraints, ObjectWithNullableProperty, ObjectWithProperty, PopulatedArray };
+/**
+ * StringConstraints interface
+ */
+interface StringConstraints
+{
+	/**
+	 * minLength
+	 */
+	minLength?: number;
+	/**
+	 * maxLength
+	 */
+	maxLength?: number;
+}
+
+export type { ArrayConstraints, ObjectWithNullableProperty, ObjectWithProperty, PopulatedArray, StringConstraints };


### PR DESCRIPTION
We often have the case of `value: string | undefined` and it's a bit tedious to both check for definition and non emptiness: 
``` typescript
if(TypeGuard.IsDefined(value) && value !== '') {}
// or for the orther way around
if(!TypeGuard.IsDefined(value) || value === '') {}
```
I propose to add a new typeguard for this common case inspired by the existing `TypeGuard.IsFilledString` : 
``` typescript
if(TypeGuard.IsFilled(value)) {}
```

It's just syntax sugar to save double checks for this specific case.

Plus, I added constraints to the `IsString` guard and assert to match the `IsArray` util as requested by @blephy 